### PR TITLE
testDeviceInfoPrint: Add test for device info printing functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,14 @@ target_include_directories(test_cusolver_getrf PRIVATE ${CUDAToolkit_INCLUDE_DIR
 target_link_libraries(test_cusolver_getrf PRIVATE fmt::fmt GTest::gtest_main CUDA::cudart CUDA::cusolver)
 add_test(NAME TestCusolverGetrf COMMAND test_cusolver_getrf)
 
+# Test for common::print_device_info
+add_executable(test_device_info_print tests/test_device_info_print.cpp)
+# Explicitly add CUDA include directories for the C++ compiler
+target_include_directories(test_device_info_print PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+# Link against fmt, gtest, and CUDA runtime
+target_link_libraries(test_device_info_print PRIVATE fmt::fmt GTest::gtest_main CUDA::cudart)
+add_test(NAME TestDeviceInfoPrint COMMAND test_device_info_print)
+
 
 # --- CUDA Check (Optional, informational) ---
 find_package(CUDAToolkit)

--- a/include/common/device_info_print.cuh
+++ b/include/common/device_info_print.cuh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <fmt/core.h>
+
+#include "common/error_check.cuh"  // 包含错误检查宏
+
+namespace qui1 {
+namespace common {
+
+/**
+ * @brief 打印当前 CUDA 设备的名称。
+ *
+ * 该函数获取当前活动的 CUDA 设备的属性，并使用 fmt 库打印其名称。
+ * 如果获取设备属性或设备名称时发生 CUDA 错误，将调用 CUDA_CHECK 宏进行错误处理。
+ */
+inline void print_device_info() {
+    int device_id = 0;
+    CUDA_CHECK(cudaGetDevice(&device_id));  // 获取当前设备 ID
+    cudaDeviceProp device_prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_id));  // 获取设备属性
+    fmt::print("Using device: {}\n", device_prop.name);  // 使用 fmt 打印设备名称
+}
+
+}  // namespace common
+}  // namespace qui1

--- a/tests/test_device_info_print.cpp
+++ b/tests/test_device_info_print.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include "common/device_info_print.cuh" // 包含我们要测试的头文件
+#include "common/error_check.cuh" // 包含 CUDA_CHECK 宏定义
+
+// 测试 print_device_info 函数
+TEST(DeviceInfoPrintTest, PrintsWithoutError) {
+    // 这个测试的主要目的是确保函数能够成功执行，
+    // 调用 CUDA API 并使用 fmt 打印，而不会抛出任何 CUDA 错误或 C++ 异常。
+    // 由于设备名称会根据实际硬件变化，我们不检查具体的输出字符串，
+    // 只验证函数调用本身是否正常。
+    EXPECT_NO_THROW({
+        // 将调用放在代码块中，以确保任何潜在的异常都能被 EXPECT_NO_THROW 捕获
+        qui1::common::print_device_info();
+    });
+
+    // 也可以添加一个检查，确保至少有一个 CUDA 设备可用
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    // 如果没有设备，打印函数内部的 cudaGetDevice 可能会失败，
+    // 但 CUDA_CHECK 会处理它。这里我们额外检查一下。
+    if (err == cudaErrorNoDevice) {
+        GTEST_SKIP() << "Skipping test: No CUDA devices found.";
+    }
+}


### PR DESCRIPTION
- Add new test executable for common::print_device_info
- Include CUDA toolkit directories for C++ compiler
- Link against fmt, gtest, and CUDA runtime libraries
- Register test with CTest